### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ Displays: NS BG with direction arrow, yellow hihi,high,low,lolo alarms, stale da
 * Wiring:<br />
 ** D1 on WIFI NodeMCU -to- SDA on Display<br />
 ** D2 on WIFI NodeMCU -to- SCL on Display<br />
-** 3V3 on WIFI NodeMCU -to- GND on Display<br />
-** GND on WIFI NodeMCU -to- VCC on Display<br />
+** GND on WIFI NodeMCU -to- GND on Display<br />
+** 3V3 on WIFI NodeMCU -to- VCC on Display<br />
 ** MicroUSB(powered/plugged into wall or computer, ect) -to- WIFI NodeMCU USB port<br />
 * wifi is required<br />
 


### PR DESCRIPTION
Your wiring instructions are incorrect.

They do not match your pictures, and I blew up 2 OLED screens. :(

GND should go to GND
and 3V3 should go to VCC